### PR TITLE
app-emulation/sheepshaver: fix SDL version selection

### DIFF
--- a/app-emulation/sheepshaver/sheepshaver-1.0.0_p20231008.ebuild
+++ b/app-emulation/sheepshaver/sheepshaver-1.0.0_p20231008.ebuild
@@ -55,8 +55,7 @@ src_configure() {
 		--enable-sdl-video \
 		--with-bincue \
 		--with-gtk \
-		--without-esd \
-		--without-sdl1
+		--without-esd
 }
 
 src_install() {


### PR DESCRIPTION
On my system passing --without-sdl1 when configuring sheepshaver actually causes it to look for SDL1 and ignore SDL2.  sheepshaver actually defaults to SDL2, so specifying --without-sdl1 should be redundant, and removing it fixes the build for me.