### PR TITLE
games-misc/render96ex: allow to depend on p7zip instead of 7zip

### DIFF
--- a/games-misc/render96ex/render96ex-20241202.ebuild
+++ b/games-misc/render96ex/render96ex-20241202.ebuild
@@ -36,7 +36,7 @@ RESTRICT="fetch"
 
 DEPEND="media-libs/glew:= media-libs/libsdl2 media-libs/libglvnd[X]"
 RDEPEND="${DEPEND}"
-BDEPEND="app-arch/7zip media-libs/audiofile"
+BDEPEND="|| ( app-arch/7zip app-arch/p7zip ) media-libs/audiofile"
 
 PATCHES=( "${FILESDIR}/${PN}-0001-custom-flags.patch" )
 


### PR DESCRIPTION
Tested using p7zip-7.05-r2 with no issues to report.