### PR TITLE
sci-libs/vtk: fix configure with USE=all-modules

### DIFF
--- a/sci-libs/vtk/vtk-9.7.0.ebuild
+++ b/sci-libs/vtk/vtk-9.7.0.ebuild
@@ -419,7 +419,6 @@ src_configure() {
 		-DVTK_BUILD_DOCUMENTATION=OFF
 		-DVTK_BUILD_EXAMPLES="$(usex examples)"
 
-		# no package in the tree: https://github.com/LLNL/conduit
 		-DVTK_ENABLE_CATALYST=OFF
 		-DVTK_ENABLE_KITS=OFF
 		-DVTK_ENABLE_LOGGING="$(usex logging)"
@@ -539,11 +538,18 @@ src_configure() {
 			# TODO: some of these are tied to the VTK_ENABLE_REMOTE_MODULES
 			# option. Check whether we can download them clean and enable
 			# them.
+			# no package in the tree: https://github.com/LLNL/conduit
+			-DVTK_MODULE_ENABLE_VTK_conduit="NO"
 			-DVTK_MODULE_ENABLE_VTK_DomainsMicroscopy="NO"
 			-DVTK_MODULE_ENABLE_VTK_fides="NO"
+			-DVTK_MODULE_ENABLE_VTK_FiltersONNX="NO"
 			-DVTK_MODULE_ENABLE_VTK_FiltersOpenTURNS="NO"
 			-DVTK_MODULE_ENABLE_VTK_IOADIOS2="NO"
 			-DVTK_MODULE_ENABLE_VTK_IOFides="NO"
+			-DVTK_MODULE_ENABLE_VTK_IOIFC="NO"
+			# writer uses the pre-OpenVDB-11 NanoVDB API
+			-DVTK_MODULE_ENABLE_VTK_IONanoVDB="NO"
+			-DVTK_MODULE_ENABLE_VTK_IOUSD="NO"
 
 			-DVTK_MODULE_ENABLE_VTK_RenderingOpenVR="NO"
 			-DVTK_MODULE_ENABLE_VTK_RenderingOpenXR="NO"


### PR DESCRIPTION
Fixes #727.

`VTK_BUILD_ALL_MODULES=ON` requests five modules whose externals are not packaged, so they are added to the existing `if use all-modules` block:

| Module | External | Status |
| --- | --- | --- |
| `VTK::conduit` | Conduit | no ebuild |
| `VTK::FiltersONNX` | onnxruntime | no ebuild |
| `VTK::IOIFC` | IfcOpenShell | no ebuild |
| `VTK::IOUSD` | pxr (OpenUSD) | no ebuild |
| `VTK::IONanoVDB` | OpenVDB nanovdb | found, but does not compile |

The first four fail configure via `vtk_module_find_package(... REQUIRED)`. `VTK::conduit` moved to `Utilities/Conduit` in 9.7 and is no longer gated by `VTK_ENABLE_CATALYST`, so the comment on that option is removed.

`VTK::IONanoVDB` configures fine (`media-gfx/openvdb-12.0.1` has `+nanovdb`) but fails to compile: `vtkNanoVDBWriter.cxx` uses `nanovdb/util/CreateNanoGrid.h`, `nanovdb::build::` and `nanovdb::createNanoGrid`, which OpenVDB 11 moved under `nanovdb::tools::`.

```
IO/NanoVDB/vtkNanoVDBWriter.cxx:219:49: error: 'nanovdb::build' has not been declared
IO/NanoVDB/vtkNanoVDBWriter.cxx:313:39: error: 'createNanoGrid' is not a member of 'nanovdb'
```

openvdb-12.0.1 is the only version in ::gentoo, so no version condition applies.

Note: if `IONanoVDB` is ever enabled, line 108 needs `media-gfx/openvdb:=[nanovdb]` — `nanovdb` is a USE flag.

Tested on amd64, `USE=all-modules`, by pre-seeding the same five cache entries via `CMAKE_EXTRA_CACHE_FILE`: configure completes and the build is past 3800/11290 targets with no errors, emitting no targets for any of the five modules. No revbump, as the package does not build with these settings today.
